### PR TITLE
Adjusted WebRTCBase to allow pass-through props

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -494,6 +494,7 @@ export default (ComposedComponent) => {
     render() {
       return (
         <ComposedComponent
+          {...this.props}
           params={this.props.params}
           initializeWebRTC={this._initializeWebRTC.bind(this)}
           onAudioMute={this._onAudioMute.bind(this)}


### PR DESCRIPTION
I've made a minor change so that we can pass additional props to the component wrapped by WebRTCBase. 