### PR TITLE
Changes for chat updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "request-promise-native": "^1.0.3",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "babel-cli": "6.10.1",


### PR DESCRIPTION
- [x] Move management of Chat History back to the appserver and out of react SDK 
- [x] Add UUID's required to send messages now for root/child nodes
- [x] Add event to emit `onChatMessageReceived` for creating a new callback in client
- [x] Add userData fields required on initialization
- [x] Use `createSession` instead of `createSessionWithRoomId`